### PR TITLE
update link to Rook Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A resource tracking a number of Kubernetes extensions.
 
 Please send a pull request if you are using Kubernetes Third-Party Resources, Custom Resource Definitions, or the API Server Aggregation and we will add you to the list.
 
-- Rook Operator: https://github.com/rook/rook/tree/master/demo/kubernetes
+- Rook Operator: https://github.com/rook/rook/tree/master/cluster/examples/kubernetes
 - Elasticsearch Operator: https://github.com/upmc-enterprises/elasticsearch-operator
 - Etcd Operator: https://coreos.com/blog/introducing-the-etcd-operator.html
 - Prometheus Operator: https://coreos.com/blog/the-prometheus-operator.html


### PR DESCRIPTION
This fixes the link to the Rook Operator since it changed paths in the Rook repo.  The current link results in a 404.